### PR TITLE
[FIX] fixed all notice, alert, and error message layout

### DIFF
--- a/app/assets/stylesheets/admins.scss
+++ b/app/assets/stylesheets/admins.scss
@@ -1,3 +1,8 @@
 // Place all the styles related to the admins controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
+
+.error-message {
+    color: rgb(207, 15, 15);
+    font-weight: 600;
+}

--- a/app/assets/stylesheets/sessions.scss
+++ b/app/assets/stylesheets/sessions.scss
@@ -2,6 +2,34 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
+.notice {
+    font-size: 1rem;
+    color: rgba(28, 129, 28, 0.748);
+    font-weight: 600;
+    background-color: transparent;
+    z-index: 1;
+}
+
+.alert {
+    font-size: 1rem;
+    color: rgb(207, 15, 15);
+    font-weight: 600;
+    background-color: transparent;
+    z-index: 1;
+}
+
+#error_explanation {
+    font-size: 1rem;
+    color: rgb(207, 15, 15);
+    font-weight: 600;
+    background-color: transparent;
+    z-index: 1;
+}
+
+#error_explanation h2:nth-child(1) {
+    display: none;
+}
+
 .new-session,
 .register-session {
     position: relative;
@@ -48,7 +76,7 @@
 
 .registration-form {
     max-width: 100%;
-    gap: 10%;
+    gap: 5%;
     margin: 0 auto;
 }
 
@@ -69,6 +97,11 @@
 
 .sessions-input {
     width: 16.5rem;
+    // height: 3rem;
+}
+
+.sessions-input input {
+    width: 100% !important;
 }
 
 .actions .login-btn {
@@ -157,9 +190,25 @@
     }
 
     .field input {
-        width: 15rem;
+        width: 100%;
         height: 1rem;
         font-size: 0.75rem;
+        border: 1px solid #181717;
+        outline: none;
+    }
+
+    #user_email,
+    #user_password {
+        width: 17rem;
+    }
+
+    .admin-field input {
+        width: 75%;
+    }
+
+    .admin-field #user_email,
+    .admin-field #user_password {
+        width: 75%;
     }
 
     .actions .register-btn {
@@ -191,7 +240,36 @@
     }
 }
 
+@media screen and (max-width: 1024px){
+    .field input {
+        height: 3rem;
+    }
+}
+
 @media screen and (max-width: 768px) {
+    .registration-form {
+        flex-direction: column;
+    }
+
+    #user_email,
+    #user_password {
+        width: 12rem;
+        height: 1rem;
+        font-size: 0.75rem;
+        margin: 0 auto;
+        left: 10rem;
+        // transform: translateX(3.5rem);
+    }
+
+    .admin-field input {
+        width: 75% !important;
+    }
+
+    .admin-field #user_email,
+    .admin-field #user_password {
+        width: 75%;
+    }
+
     .new-session-h1,
     .registration-session-h1 {
         font-size: 1rem;
@@ -218,7 +296,7 @@
     }
 
     .forgot-btn, .to-login-btn {
-        font-size: 1rem;
+        font-size: 0.75rem;
     }
 
     .footer {
@@ -234,5 +312,17 @@
     .register-session-svg {
         width: 50px;
         height: 150px;
+    }
+}
+
+@media screen and (max-width: 375px) {
+    .new-session-span, .register-session-span {
+        font-size: 0.75rem;
+    }
+}
+
+@media screen and (max-width: 320px) {
+    .new-session-span, .register-session-span {
+        font-size: 0.69rem;
     }
 }

--- a/app/views/admins/sessions/_form.html.erb
+++ b/app/views/admins/sessions/_form.html.erb
@@ -1,4 +1,8 @@
 <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: {class: 'new-session-form is-flex is-flex-direction-column is-align-items-center'}) do |f| %>
+  <p class="notice"><%= notice %></p>
+  <p class="alert"><%= alert %></p>
+  <br/>
+  
   <div class="field sessions-input">
     <%= f.email_field :email, autocomplete: "email", placeholder: '✉️ Email' %>
   </div>

--- a/app/views/admins/shared/_add_dash.html.erb
+++ b/app/views/admins/shared/_add_dash.html.erb
@@ -20,21 +20,20 @@
                 <div class="left">
                     <h3>Add Trader</h3><hr/>
                     <%= form_with scope: :user, model: @user, url: '/admins/add_trader', method: :post, local: true do |f| %>
-                        <div class="field">
-                            
+                        <div class="field admin-field">
                             <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "✉️ Email" %><br/>
                             <% @user.errors.full_messages_for(:email).each do |message| %>
-                            <div><%= message %></div>
+                            <div class="error-message"><%= message %></div>
                             <% end %>
                             <br/>
                             <%= f.text_field :fullname, autofocus: true, autocomplete: :off, placeholder: "👤 Fullname" %><br/>
                             <% @user.errors.full_messages_for(:fullname).each do |message| %>
-                            <div><%= message %></div>
+                            <div class="error-message"><%= message %></div>
                             <% end %>
                             <br/>
-                            <%= f.password_field :password, autocomplete: "new-password", placeholder: "🔒 Password (6 characters minimum)" %>
+                            <%= f.password_field :password, autocomplete: "new-password", placeholder: "🔒 Password (6 characters minimum)" %><br/>
                             <% @user.errors.full_messages_for(:password).each do |message| %>
-                            <div><%= message %></div>
+                            <div class="error-message"><%= message %></div>
                             <% end %>
                         </div>
                         <div class="actions">

--- a/app/views/admins/shared/_edit_dash.html.erb
+++ b/app/views/admins/shared/_edit_dash.html.erb
@@ -20,15 +20,15 @@
                 <div class="left">
                     <h3>Edit Trader</h3><hr/>
                     <%= form_with scope: :user, model: @user, url: trader_profile_path, method: :put, local: true  do |f| %>
-                        <div class="field">
-                            <%= f.email_field :email, autofocus: true, value: @user.email, placeholder: "✉️ Email" %><br/
+                        <div class="field admin-field">
+                            <%= f.email_field :email, autofocus: true, value: @user.email, placeholder: "✉️ Email" %><br/>
                             <% @user.errors.full_messages_for(:email).each do |message| %>
-                            <div><%= message %></div>
+                            <div class="error-message"><%= message %></div>
                             <% end %>
                             <br/>
                             <%= f.text_field :fullname, autofocus: true, value: @user.fullname, placeholder: "👤 Fullname" %><br/>
                             <% @user.errors.full_messages_for(:fullname).each do |message| %>
-                            <div><%= message %></div>
+                            <div class="error-message"><%= message %></div>
                             <% end %>
                             <br/>
                             <%= f.number_field :balance, autofocus: true, value: @user.wallet.balance , placeholder: "$ Balance" %> <br/><br/>

--- a/app/views/devise/registrations/_form.html.erb
+++ b/app/views/devise/registrations/_form.html.erb
@@ -1,7 +1,8 @@
 <%= form_for(resource, as: resource_name, url: users_sign_up_path, html: {class: 'registration-session-form is-flex is-flex-direction-column is-align-items-center'}) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
+  <br/>
 
-  <div class="registration-form is-flex is-flex-direction-row is-align-items-center is-justify-content-center">
+  <div class="registration-form is-flex is-align-items-center is-justify-content-center">
 
     <div class="left-form">
 

--- a/app/views/devise/sessions/_form.html.erb
+++ b/app/views/devise/sessions/_form.html.erb
@@ -1,4 +1,8 @@
 <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: {class: 'new-session-form is-flex is-flex-direction-column is-align-items-center'}) do |f| %>
+  <p class="notice"><%= notice %></p>
+  <p class="alert"><%= alert %></p>
+  <br/>
+  
   <div class="field sessions-input">
     <%= f.email_field :email, autocomplete: "email", placeholder: '✉️ Email' %>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,8 +14,6 @@
   </head>
 
   <body>
-    <p class="notice"><%= notice %></p>
-    <p class="alert"><%= alert %></p>
     <%= yield %>
   </body>
 </html>


### PR DESCRIPTION
## Summary

I fixed all notice, alert, and error messages layout on both user and admin side.

## Screenshots

### **Users**

**User Login Validations**
![Screenshot from 2022-03-11 18-19-04](https://user-images.githubusercontent.com/82153590/157848390-f0d6fadb-43bf-4625-81a9-5965962fbde5.png)

**User Registration Validations**
![Screenshot from 2022-03-11 18-19-25](https://user-images.githubusercontent.com/82153590/157848451-e23da135-0ae6-4ed1-9c3e-b29b1649618c.png)

**User Logged Out**
![Screenshot from 2022-03-11 18-19-57](https://user-images.githubusercontent.com/82153590/157848597-160f735b-00d7-4106-869a-eead14b33e31.png)

### **Admin**

**Admin Login Validations**
![Screenshot from 2022-03-11 18-21-43](https://user-images.githubusercontent.com/82153590/157848880-3644f24b-05c0-4646-b767-2b9d5849eeb5.png)

**Create Trader Validations**
![Screenshot from 2022-03-11 18-22-31](https://user-images.githubusercontent.com/82153590/157848972-c545b16f-365e-4551-8c6a-89fc4abb02ea.png)

**Edit Trader Validations**
![Screenshot from 2022-03-11 18-23-05](https://user-images.githubusercontent.com/82153590/157849087-c5b19f2b-41d9-4bea-b575-b717ad25d0b0.png)

**Admin Logged Out**
![Screenshot from 2022-03-11 18-23-41](https://user-images.githubusercontent.com/82153590/157849159-4f760df1-d48e-422a-afee-d7085cbc1cb8.png)
